### PR TITLE
fix(style): modify the table header font size constant to use var

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -768,6 +768,7 @@ $table: map.merge(
     'border-color': getCssVar('border-color-lighter'),
     'border': 1px solid getCssVar('table-border-color'),
     'text-color': getCssVar('text-color-regular'),
+    'font-size': getCssVar('font-size', 'base'),
     'header-text-color': getCssVar('text-color-secondary'),
     'row-hover-bg-color': getCssVar('fill-color', 'light'),
     'current-row-bg-color': getCssVar('color-primary-light-9'),

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -16,7 +16,7 @@
   width: 100%;
   max-width: 100%;
   background-color: getCssVar('table-bg-color');
-  font-size: 14px;
+  font-size: getCssVar('table-font-size');
   color: getCssVar('table-text-color');
 
   @include e(inner-wrapper) {


### PR DESCRIPTION
closed #15192

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.

## Description

modify the table header font size constant to use var

## Related Issue

Fixes #15192.

## Explanation of Changes

modify the table header font size constant to use var
